### PR TITLE
fix: handle keyboard height of iPhone X

### DIFF
--- a/src/platform/platform-registry.ts
+++ b/src/platform/platform-registry.ts
@@ -109,7 +109,10 @@ export const PLATFORM_CONFIGS: { [key: string]: PlatformConfig } = {
       hoverCSS: false,
       inputBlurring: isIos,
       inputCloning: isIos,
-      keyboardHeight: 250,
+      keyboardHeight: function(plt: Platform): number {
+        let isIphoneX = plt.width() === 375 && plt.height() === 812;
+        return isIphoneX ? 325 : 250;
+      },
       mode: 'ios',
       statusbarPadding: isCordova,
       swipeBackEnabled: isIos,


### PR DESCRIPTION
#### Short description of what this resolves:
If keyboard is visible on iPhone X the content's scrolled padding is incorrectly calculated.
https://github.com/ionic-team/ionic/blob/v3.9.2/src/components/input/input.ts#L276

#### Changes proposed in this pull request:

- detect iPhone X (based on width and height)
- set `keyboardHeight` to 325

**Ionic Version**: 3.x